### PR TITLE
Fix typo in sequence diagram subtopic (UML BASICS section)

### DIFF
--- a/LLD/01-fundamentals/03-uml-basics.md
+++ b/LLD/01-fundamentals/03-uml-basics.md
@@ -240,7 +240,7 @@ flowchart LR
 - Shows how objects interact over time.
 - A sequence diagram is a type of UML (Unified Modeling Language) diagram that shows how objects in a system interact with each other, step by step.
 - It focuses on the order of messages exchanged between different components or actors to achieve a particular task or use case.
-- **"Who is doing what and when"**
+- **"Who is doing what and when?"**
 - A **Sequence Diagram** in UML is used to represent the flow of messages between different objects or components over time.
 - It shows **how objects interact** through different types of **messages**.
 


### PR DESCRIPTION
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧹 Code cleanup or refactor
- [ ] 🧪 Tests added or updated
- [ ] 📘 Documentation update

Fixed Typo in UML Basics under the Sequence Diagram section:

**Before:** "Who is `doint` what and when ?"

**After:** "Who is `doing` what and when?"





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typographical error in the UML basics documentation guide. The Sequence Diagram section description has been updated to accurately read: "Who is doing what and when?" This fix removes the spelling mistake from the original phrasing, enhancing overall documentation quality, clarity, and accuracy for all end-users consulting these educational materials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->